### PR TITLE
Security upgrade node from 16 to 19.6.0-bullseye-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:19.6.0-bullseye-slim
 MAINTAINER totaljs "info@totaljs.com"
 
 RUN apt-get update


### PR DESCRIPTION
Security upgrade node from 16 to 19.6.0-bullseye-slim